### PR TITLE
Add .bin files to .gitignore and integrate Ollama feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,11 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
 	"features": {
-		"ghcr.io/va-h/devcontainers-features/uv:1": {}
+		"ghcr.io/va-h/devcontainers-features/uv:1": {
+			"shellautocompletion": true,
+			"version": "latest"
+		},
+		"ghcr.io/prulloac/devcontainer-features/ollama:1": {}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ cython_debug/
 *.sqlite
 *.db
 *.db-journal
+*.bin


### PR DESCRIPTION
Exclude .bin files from version control and add the Ollama feature to the development container configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development container configuration to enhance features and add new tooling support.
	- Updated .gitignore to exclude files with the .bin extension from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->